### PR TITLE
TestScaffold: startTo: suspend running threads if debugging is started on demand

### DIFF
--- a/test/jdk/com/sun/jdi/TestScaffold.java
+++ b/test/jdk/com/sun/jdi/TestScaffold.java
@@ -374,6 +374,11 @@ abstract public class TestScaffold extends TargetAdapter {
                                       String methodName, String signature) {
         startUp(targetName);
         traceln("TS: back from startUp");
+        
+        if (delayedStart) {
+            // suspend running threads to avoid race between suspend upon breakpoint event and resume
+            vm.suspend();
+        }
 
         BreakpointEvent bpr = resumeTo(targetName, methodName,
                                        signature);


### PR DESCRIPTION
TestScaffold.startTo() has a race codition when debugging is started on demand, because at that
point all debuggee threads are running when resumeTo() is called. The race is between suspend upon
hitting the breakpoint and the resume after setting the breakpoint. If the resume occurs after the
suspend we get an com.sun.jdi.IncompatibleThreadStateException when trying to retrieve the frames in
ListenerTest.runTests().